### PR TITLE
add port I/O classes, fix build failure and fix entry point of kernel in linker.ld

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 CXX = g++
-CXXFLAGS = -m32 -Iinclude -fno-use-cxa-atexit -nostdlib -fno-builtin\
+CXXFLAGS = -std=c++11 -m32 -Iinclude -fno-use-cxa-atexit -nostdlib -fno-builtin\
 	   -fno-rtti -fno-exceptions -fno-leading-underscore -Wno-write-strings
 
 AS = nasm

--- a/include/port.h
+++ b/include/port.h
@@ -1,0 +1,59 @@
+// Copyright (c) 2019 FunSociety
+#ifndef HEY_OS_PORT_H_
+#define HEY_OS_PORT_H_
+
+#include <type.h>
+
+namespace heyos {
+
+class Port {
+ protected:
+  Port(uint16_t port_number) : port_number_(port_number) {}
+  ~Port() = default;
+
+  virtual void wait() const;
+  uint16_t port_number_;
+};
+
+
+class Port8Bit : public Port {
+ public:
+  Port8Bit(uint16_t port_number) : Port(port_number) {}
+  ~Port8Bit() = default;
+
+  virtual void write(uint8_t data) const;
+  virtual uint8_t read() const;
+};
+
+
+class Port8BitSlow : public Port8Bit {
+ public:
+  Port8BitSlow(uint16_t port_number) : Port8Bit(port_number) {}
+  ~Port8BitSlow() = default;
+
+  virtual void write(uint8_t data) const override;
+};
+
+
+class Port16Bit : public Port {
+ public:
+  Port16Bit(uint16_t port_number) : Port(port_number) {}
+  ~Port16Bit() = default;
+
+  virtual void write(uint16_t data) const;
+  virtual uint16_t read() const;
+};
+
+
+class Port32Bit : public Port {
+ public:
+  Port32Bit(uint16_t port_number) : Port(port_number) {}
+  ~Port32Bit() = default;
+
+  virtual void write(uint32_t data) const;
+  virtual uint32_t read() const;
+};
+
+}  // namespace heyos
+
+#endif // HEY_OS_PORT_H_

--- a/kernel/loader.S
+++ b/kernel/loader.S
@@ -35,6 +35,9 @@ stack_top:
 ; Call start_kernel()
 section .text
   extern start_kernel              ; start_kernel() is declared in main.cpp
+  global kernel_loader
+
+kernel_loader:
   mov esp, stack_top               ; Point esp to the top of the stack
   push ebx                         ; start_kernel()'s first param: multiboot structure
   call start_kernel                ; Continue executing our kernel in main.cpp

--- a/kernel/port.cc
+++ b/kernel/port.cc
@@ -1,0 +1,47 @@
+// Copyright (c) 2019 FunSociety
+#include <port.h>
+
+namespace heyos {
+
+void Port::wait() const {
+  __asm__ volatile("jmp 1f;1:jmp 1f;1:");
+}
+
+void Port8Bit::write(uint8_t data) const {
+  __asm__ volatile("outb %0, %1" : : "a"(data), "Nd"(port_number_));
+}
+
+uint8_t Port8Bit::read() const {
+  uint8_t data;
+  __asm__ volatile("inb %1, %0" : "=a"(data) : "Nd"(port_number_));
+  return data;
+}
+
+void Port8BitSlow::write(uint8_t data) const {
+  Port8Bit::write(data);
+  Port::wait();
+}
+
+
+void Port16Bit::write(uint16_t data) const {
+  __asm__ volatile("outw %0, %1" : : "a"(data), "Nd"(port_number_));
+}
+
+uint16_t Port16Bit::read() const {
+  uint16_t data;
+  __asm__ volatile("inw %1, %0" : "=a"(data) : "Nd"(port_number_));
+  return data;
+}
+
+
+void Port32Bit::write(uint32_t data) const {
+  __asm__ volatile("outl %0, %1" : : "a"(data), "Nd"(port_number_));
+}
+
+uint32_t Port32Bit::read() const {
+  uint32_t data;
+  __asm__ volatile("inl %1, %0" : "=a"(data) : "Nd"(port_number_));
+  return data;
+}
+
+}  // namespace heyos

--- a/linker.ld
+++ b/linker.ld
@@ -1,4 +1,4 @@
-ENTRY(_loader)
+ENTRY(kernel_loader)
 OUTPUT_FORMAT(elf32-i386)
 OUTPUT_ARCH(i386:i386)
 


### PR DESCRIPTION
The inline assembly are borrowed from:
https://wiki.osdev.org/Inline_Assembly/Examples#I.2FO_access